### PR TITLE
Fix protected all routes from accessing without authorized

### DIFF
--- a/client/api/build-client.js
+++ b/client/api/build-client.js
@@ -5,7 +5,8 @@ export default ({ req }) => {
     // We are on the server
 
     return axios.create({
-      baseURL: "http://aurapan.com",
+      baseURL:
+        "http://ingress-nginx-controller.ingress-nginx.svc.cluster.local",
       headers: req.headers,
       withCredentials: true,
     });

--- a/client/components/Header.js
+++ b/client/components/Header.js
@@ -118,12 +118,6 @@ const Header = ({ currentUser, orders }) => {
   );
 };
 
-// Header.getInitialProps = async (context, client) => {
-//   let { data } = await client.get(`/api/orders/myorders`);
-
-//   return { orders: data };
-// };
-
 export async function getServerSideProps(context) {
   const client = buildClient(context);
   const { data: orderData } = await client.get("/api/orders");

--- a/client/components/Product.js
+++ b/client/components/Product.js
@@ -61,7 +61,9 @@ const Product = ({ product, currentUser }) => {
           />
         </Card.Text>
 
-        <AddToCart product={product} currentUser={currentUser} />
+        {currentUser?.isAdmin ? (
+          <AddToCart product={product} currentUser={currentUser} />
+        ) : null}
       </Card.Body>
     </Card>
   );

--- a/client/pages/[productId].js
+++ b/client/pages/[productId].js
@@ -1,6 +1,5 @@
-import React from "react";
-import Router, { useRouter } from "next/router";
-import Link from "next/link";
+import React, { useState } from "react";
+import { useRouter } from "next/router";
 // import Swiper core and required modules
 import { Navigation, Pagination, Scrollbar, Zoom } from "swiper";
 
@@ -16,18 +15,27 @@ import "swiper/css/zoom";
 
 import NextImage from "../components/NextImage";
 import buildClient from "../api/build-client";
+import Loader from "../components/Loader";
 
 const test = ({ products, currentUser }) => {
+  const [imageArray, setImageArray] = useState([]);
+  const [loading, setLoading] = useState(true);
+
   const { productId } = useRouter().query;
   const product = products.find((product) => product.id === productId);
 
-  let allImages = [];
-  for (const img in product.images) {
-    if (product.images[img] !== "" && typeof product.images[img] === "string") {
-      allImages.push(product.images[img]);
-    }
+  if (imageArray.length === 0 && product) {
+    const filterImages = Object.values(product.images).filter(
+      (image) => image !== null && image !== ""
+    );
+
+    setLoading(false);
+    setImageArray(filterImages);
   }
-  return (
+
+  return loading ? (
+    <Loader />
+  ) : (
     <Swiper
       // install Swiper modules
       modules={[Navigation, Pagination, Scrollbar, Zoom]}
@@ -42,7 +50,7 @@ const test = ({ products, currentUser }) => {
       onSwiper={(swiper) => console.log(swiper)}
       onSlideChange={() => console.log("slide change")}
     >
-      {allImages.map((img, index) => (
+      {imageArray.map((img, index) => (
         <SwiperSlide key={index}>
           <div
             className="product-main-img toggle-main-img"

--- a/client/pages/_app.js
+++ b/client/pages/_app.js
@@ -51,20 +51,20 @@ const MyApp = ({ Component, pageProps, currentUser }) => {
 
 MyApp.getInitialProps = async (appContext) => {
   const client = buildClient(appContext.ctx);
-  const { data: currentUserData } = await client.get("/api/users/currentuser");
+  const { data: data } = await client.get("/api/users/currentuser");
 
   let pageProps = {};
-  // if (appContext.Component.getInitialProps) {
-  //   pageProps = await appContext.Component.getInitialProps(
-  //     appContext.ctx,
-  //     client,
-  //     currentUserData.currentUser
-  //   );
-  // }
+  if (appContext.Component.getInitialProps) {
+    pageProps = await appContext.Component.getInitialProps(
+      appContext.ctx,
+      client,
+      data.currentUser
+    );
+  }
 
   return {
     pageProps,
-    ...currentUserData,
+    ...data,
   };
 };
 

--- a/client/pages/_app.js
+++ b/client/pages/_app.js
@@ -51,20 +51,20 @@ const MyApp = ({ Component, pageProps, currentUser }) => {
 
 MyApp.getInitialProps = async (appContext) => {
   const client = buildClient(appContext.ctx);
-  const { data } = await client.get("/api/users/currentuser");
+  const { data: currentUserData } = await client.get("/api/users/currentuser");
 
   let pageProps = {};
-  if (appContext.Component.getInitialProps) {
-    pageProps = await appContext.Component.getInitialProps(
-      appContext.ctx,
-      client,
-      data.currentUser
-    );
-  }
+  // if (appContext.Component.getInitialProps) {
+  //   pageProps = await appContext.Component.getInitialProps(
+  //     appContext.ctx,
+  //     client,
+  //     currentUserData.currentUser
+  //   );
+  // }
 
   return {
     pageProps,
-    ...data,
+    ...currentUserData,
   };
 };
 

--- a/client/pages/admin/index.js
+++ b/client/pages/admin/index.js
@@ -81,21 +81,28 @@ export async function getServerSideProps(context) {
   const client = buildClient(context);
   const { data } = await client.get("/api/users/currentuser");
 
-  // Redirect to signin page if user do not authorized
-  if (data.currentUser === null) {
-    return {
-      redirect: {
-        destination: "/signin",
-        permanent: false,
-      },
-    };
-  } else {
+  // Redirect to signin page or home if user do not authorized
+  if (data.currentUser?.isAdmin) {
     const { data: productData } = await client.get("/api/products");
     const { data: userData } = await client.get("/api/users");
     const { data: orderData } = await client.get("/api/orders");
 
     return {
       props: { products: productData, users: userData, orders: orderData },
+    };
+  } else if (data.currentUser?.isAdmin === false) {
+    return {
+      redirect: {
+        destination: "/",
+        permanent: false,
+      },
+    };
+  } else {
+    return {
+      redirect: {
+        destination: "/signin",
+        permanent: false,
+      },
     };
   }
 }

--- a/client/pages/admin/index.js
+++ b/client/pages/admin/index.js
@@ -21,30 +21,7 @@ const DynamicTabPane = dynamic(() => import("react-bootstrap/TabPane"), {
   ssr: false,
 });
 
-const AdminDashboard = ({ products, users, orders, currentUser }) => {
-  // const [loading, setLoading] = useState(false);
-
-  console.log("products", products);
-  console.log("users", users);
-  console.log("orders", orders);
-
-  // useEffect(() => {
-  //   if (!currentUser || !currentUser.isAdmin) {
-  //     Router.push("/signin");
-  //   }
-  // }, []);
-
-  // const deleteHandler = async (id) => {
-  //   setLoading(true);
-  //   await axios.delete(`/api/products/${id}`);
-  //   setLoading(false);
-  // };
-
-  // const createProductHandler = (e) => {
-  //   e.preventDefault();
-  //   Router.push("/admin/create-product");
-  // };
-
+const AdminDashboard = ({ products, users, orders }) => {
   return (
     <Container className="app-container admin-dashboard">
       <h1>Admin Dashboard</h1>
@@ -102,13 +79,25 @@ const AdminDashboard = ({ products, users, orders, currentUser }) => {
 
 export async function getServerSideProps(context) {
   const client = buildClient(context);
-  const { data: productData } = await client.get("/api/products");
-  const { data: userData } = await client.get("/api/users");
-  const { data: orderData } = await client.get("/api/orders");
+  const { data } = await client.get("/api/users/currentuser");
 
-  return {
-    props: { products: productData, users: userData, orders: orderData },
-  };
+  // Redirect to signin page if user do not authorized
+  if (data.currentUser === null) {
+    return {
+      redirect: {
+        destination: "/signin",
+        permanent: false,
+      },
+    };
+  } else {
+    const { data: productData } = await client.get("/api/products");
+    const { data: userData } = await client.get("/api/users");
+    const { data: orderData } = await client.get("/api/orders");
+
+    return {
+      props: { products: productData, users: userData, orders: orderData },
+    };
+  }
 }
 
 export default AdminDashboard;

--- a/client/pages/cart.js
+++ b/client/pages/cart.js
@@ -8,8 +8,6 @@ import CheckoutSteps from "../components/CheckoutSteps";
 import NextImage from "../components/NextImage";
 
 const CartPage = ({ currentUser }) => {
-  // const { productId } = useRouter().query;
-
   const [productId, setProductId] = useState(null);
   const [qty, setQty] = useState(null);
   const [deletedItemId, setDeletedItemId] = useState(null);

--- a/client/pages/checkout.js
+++ b/client/pages/checkout.js
@@ -7,6 +7,7 @@ import useRequest from "../hooks/use-request";
 import CheckoutSteps from "../components/CheckoutSteps";
 import NextImage from "../components/NextImage";
 import Message from "../components/Message";
+import buildClient from "../api/build-client";
 
 const CheckoutPage = ({ currentUser }) => {
   const [storageReady, setStorageReady] = useState(false);
@@ -51,7 +52,7 @@ const CheckoutPage = ({ currentUser }) => {
       paymentData !== undefined
     ) {
       cartItemsData.map((item) => {
-        item.userId = currentUser?.id;
+        item.userId = currentUser.id;
       });
 
       // Set cart state to cartItems in localStorage
@@ -210,5 +211,20 @@ const CheckoutPage = ({ currentUser }) => {
     </>
   ) : null;
 };
+
+export async function getServerSideProps(context) {
+  const client = buildClient(context);
+  const { data } = await client.get("/api/users/currentuser");
+
+  // Redirect to signin page if user do not authorized
+  if (data.currentUser === null) {
+    return {
+      redirect: {
+        destination: "/signin",
+        permanent: false,
+      },
+    };
+  }
+}
 
 export default CheckoutPage;

--- a/client/pages/dashboard/index.js
+++ b/client/pages/dashboard/index.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
 import { Button, Form, Row, Col, Table } from "react-bootstrap";
-import Router from "next/router";
 import Link from "next/link";
 
 import Message from "../../components/Message";
@@ -54,10 +53,6 @@ const Dashboard = ({ currentUser, orders }) => {
   });
 
   useEffect(() => {
-    if (!currentUser) {
-      Router.push("/signin");
-    }
-
     if (currentUser.email) {
       setName(currentUser.name);
       setEmail(currentUser.email);
@@ -244,9 +239,21 @@ const Dashboard = ({ currentUser, orders }) => {
 
 export async function getServerSideProps(context) {
   const client = buildClient(context);
-  const { data } = await client.get("/api/orders/myorders");
+  const { data } = await client.get("/api/users/currentuser");
 
-  return { props: { orders: data } };
+  // Redirect to signin page if user do not authorized
+  if (data.currentUser === null) {
+    return {
+      redirect: {
+        destination: "/signin",
+        permanent: false,
+      },
+    };
+  } else {
+    const { data } = await client.get("/api/orders/myorders");
+
+    return { props: { orders: data } };
+  }
 }
 
 export default Dashboard;

--- a/client/pages/payment.js
+++ b/client/pages/payment.js
@@ -5,11 +5,15 @@ import Router from "next/router";
 import CheckoutSteps from "../components/CheckoutSteps";
 import FormContainer from "../components/FormContainer";
 
-const PaymentPage = () => {
+const PaymentPage = ({ currentUser }) => {
   const [paymentMethod, setPaymentMethod] = useState("stripe");
   const [onSubmit, setOnSubmit] = useState(false);
 
   useEffect(() => {
+    if (!currentUser) {
+      Router.push("/signin");
+    }
+
     const shippingAddress = localStorage.getItem("shippingAddress")
       ? JSON.parse(localStorage.getItem("shippingAddress"))
       : [];

--- a/client/pages/products/edit/[productId].js
+++ b/client/pages/products/edit/[productId].js
@@ -260,11 +260,30 @@ const EditProduct = ({ products }) => {
 
 export async function getServerSideProps(context) {
   const client = buildClient(context);
-  const { data: productData } = await client.get("/api/products");
+  const { data } = await client.get("/api/users/currentuser");
 
-  return {
-    props: { products: productData },
-  };
+  // Redirect to signin page or home if user do not authorized
+  if (data.currentUser?.isAdmin) {
+    const { data: productData } = await client.get("/api/products");
+
+    return {
+      props: { products: productData },
+    };
+  } else if (data.currentUser?.isAdmin === false) {
+    return {
+      redirect: {
+        destination: "/",
+        permanent: false,
+      },
+    };
+  } else {
+    return {
+      redirect: {
+        destination: "/signin",
+        permanent: false,
+      },
+    };
+  }
 }
 
 export default EditProduct;

--- a/client/pages/shipping.js
+++ b/client/pages/shipping.js
@@ -15,6 +15,10 @@ const ShippingPage = ({ currentUser }) => {
   const [storageReady, setStorageReady] = useState(false);
 
   useEffect(() => {
+    if (!currentUser) {
+      Router.push("/signin");
+    }
+
     const data = localStorage.getItem("shippingAddress")
       ? JSON.parse(localStorage.getItem("shippingAddress"))
       : [];

--- a/client/pages/signin.js
+++ b/client/pages/signin.js
@@ -5,7 +5,7 @@ import useRequest from "../hooks/use-request";
 import { Button, Col, Form, Row } from "react-bootstrap";
 import FormContainer from "../components/FormContainer";
 
-const signin = ({ currentUser }) => {
+const signin = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
 

--- a/client/pages/signout.js
+++ b/client/pages/signout.js
@@ -2,7 +2,6 @@ import React, { useEffect } from "react";
 import Router from "next/router";
 
 import useRequest from "../hooks/use-request";
-import { Col, Row } from "react-bootstrap";
 import Loader from "../components/Loader";
 
 const signout = () => {
@@ -18,11 +17,9 @@ const signout = () => {
   }, []);
 
   return (
-    <Row>
-      <Col className="d-flex justify-content-center align-items-center">
-        <Loader />
-      </Col>
-    </Row>
+    <div className="d-flex justify-content-center align-items-center px-0">
+      <Loader />
+    </div>
   );
 };
 

--- a/client/pages/signout.js
+++ b/client/pages/signout.js
@@ -2,7 +2,8 @@ import React, { useEffect } from "react";
 import Router from "next/router";
 
 import useRequest from "../hooks/use-request";
-import { Col, Row, Spinner } from "react-bootstrap";
+import { Col, Row } from "react-bootstrap";
+import Loader from "../components/Loader";
 
 const signout = () => {
   const { doRequest } = useRequest({
@@ -18,11 +19,8 @@ const signout = () => {
 
   return (
     <Row>
-      <Col>
-        <div>
-          <h3>Signing you out</h3>
-          <Spinner animatioon="grow" />
-        </div>
+      <Col className="d-flex justify-content-center align-items-center">
+        <Loader />
       </Col>
     </Row>
   );

--- a/client/pages/signup.js
+++ b/client/pages/signup.js
@@ -6,7 +6,7 @@ import styles from "../styles/signup.module.css";
 import { Button, Col, Form, Row } from "react-bootstrap";
 import FormContainer from "../components/FormContainer";
 
-const signup = ({ currentUser }) => {
+const signup = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const { doRequest, errors } = useRequest({


### PR DESCRIPTION
`Router.push()` can only be executed on the client-side (in useEffect) in NextJS.
In the case, the page needs to fetch data from getServerSideProps before it reaches the client-side in the _useEffect_ function.
I need a solution to redirect it to the sign-in page before its returns an error by fetching data that require _curentUser_ in the middleware.

My solution is to make initial fetch _currentUser_ data to check if it is null then redirect to the sign-in page.
If it is not null then proceed to the page or run another fetch data method.

I used `getServerSideProps` and it can only be executed on the server-side and it can't access to _currentUser_ props that came from `_app.js` because it is on the server-side.
So, I just solved it by fetching _currentUser_ again by itself.

```
export async function getServerSideProps(context) {
  const client = buildClient(context);
  const { data } = await client.get("/api/users/currentuser");
 
  // Redirect to signin page if user do not authorized
  if (data.currentUser === null) {
    return {
      redirect: {
        destination: "/signin",
        permanent: false,
      },
    };
  } else {
    // fetch more data or do nothing then proceed to the page
    const { data } = await client.get("/api/orders/myorders");
 
    return { props: { orders: data } };
  }
}
```