### PR TITLE
Fix: MongoServerError: E11000 duplicate key error

### DIFF
--- a/order/src/events/listeners/ProductUpdatedListener.ts
+++ b/order/src/events/listeners/ProductUpdatedListener.ts
@@ -47,7 +47,6 @@ export class ProductUpdatedListener extends Listener<ProductUpdatedEvent> {
     }
 
     product.set({
-      id,
       title,
       price,
       image,

--- a/payment/src/events/listeners/ProductUpdatedListener.ts
+++ b/payment/src/events/listeners/ProductUpdatedListener.ts
@@ -47,7 +47,6 @@ export class ProductUpdatedListener extends Listener<ProductUpdatedEvent> {
     }
 
     product.set({
-      id,
       title,
       price,
       image,


### PR DESCRIPTION
When updating the product that does not have order & payment database make it recreate a new product.
This is a bypass method, used for development temporarily, and will fix it later.

To produce an error, update the product that existed in order & payment database with `PATCH` method by **making no change**.
The code will try to set all product properties and save them to database collection.
One of these properties is an `id` which cause an error `MongoServerError: E11000 duplicate key error`

Remove this `id` property from `set` method should make all thing works fine.